### PR TITLE
Adding PathHelper

### DIFF
--- a/Commands/AncillaryTypeComparison.cs
+++ b/Commands/AncillaryTypeComparison.cs
@@ -28,7 +28,7 @@ namespace ZoningAccelerator.Commands
 
             if(newAncillaries.Any())
             {
-                var outputPath = Path.Combine(Environment.CurrentDirectory, "UniqueAncillaryTypes.txt");
+                var outputPath = PathHelper.GetUniqueFilePath("UniqueAncillaryTypes", cityFile, ".txt");
                 FileHelper.WriteToFile(newAncillaries, outputPath);
                 Console.WriteLine($"Found {newAncillaries.Count} new ancillary types. Details written to {outputPath}.");
             }

--- a/Commands/DwellingTypeComparison.cs
+++ b/Commands/DwellingTypeComparison.cs
@@ -28,7 +28,7 @@ namespace ZoningAccelerator.Commands
 
             if (newDwellings.Any())
             {
-                var outputPath = Path.Combine(Environment.CurrentDirectory, "UniqueDwellingTypes.txt");
+                var outputPath = PathHelper.GetUniqueFilePath("UniqueDwellingTypes", cityFile, ".txt");
                 FileHelper.WriteToFile(newDwellings, outputPath);
                 Console.WriteLine($"Found {newDwellings.Count} new dwelling types. Details written to {outputPath}.");
             }

--- a/Commands/PermittedUseComparison.cs
+++ b/Commands/PermittedUseComparison.cs
@@ -28,7 +28,7 @@ namespace ZoningAccelerator.Commands
 
             if (newPermittedUses.Any())
             {
-                var outputPath = Path.Combine(Environment.CurrentDirectory, "UniquePermittedUses.txt");
+                var outputPath = PathHelper.GetUniqueFilePath( "UniquePermittedUses", filePath, ".txt");
                 FileHelper.WriteToFile(newPermittedUses, outputPath);
                 Console.WriteLine($"Found {newPermittedUses.Count} new permitted uses. Details written to {outputPath}.");
             }

--- a/Commands/TypeOfUseComparison.cs
+++ b/Commands/TypeOfUseComparison.cs
@@ -28,7 +28,7 @@ namespace ZoningAccelerator.Commands
 
             if (newTypeOfUses.Any())
             {
-                var outputPath = Path.Combine(Environment.CurrentDirectory, "UniqueTypeOfUses.txt");
+                var outputPath = PathHelper.GetUniqueFilePath("UniqueTypeOfUses", cityFile, ".txt");
                 FileHelper.WriteToFile(newTypeOfUses, outputPath);
                 Console.WriteLine($"Found {newTypeOfUses.Count} new TypeOfUses. Details written to {outputPath}.");
             }

--- a/Helpers/FileHelper.cs
+++ b/Helpers/FileHelper.cs
@@ -38,5 +38,19 @@ namespace ZoningAccelerator.Helpers
             workbook.SaveAs(filePath);
         }
 
+        public static void WriteToFileWithAutoName(List<string> lines, string prefix, string cityPath)
+        {
+            var path = PathHelper.GetUniqueFilePath(prefix, cityPath, ".txt");
+            WriteToFile(lines, path);
+        }
+
+        public static void WriteToExcelWithAutoName(
+            List<string> col1, List<string> col2, List<string> col3, List<string> col4,
+            string prefix, string cityPath)
+        {
+            var path = PathHelper.GetUniqueFilePath(prefix, cityPath, ".xlsx");
+            WriteToExcel(path, col1, col2, col3, col4);
+        }
+
     }
 }

--- a/Helpers/PathHelper.cs
+++ b/Helpers/PathHelper.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+namespace ZoningAccelerator.Helpers
+{
+    public static class PathHelper
+    {
+        public static string GetUniqueFilePath(string prefix, string cityPath, string extension)
+        {
+            var exeFolder = AppContext.BaseDirectory;
+
+            var saveDirectory = Path.Combine(exeFolder, "Saved Files");
+
+            if (!Directory.Exists(saveDirectory))
+                Directory.CreateDirectory(saveDirectory);
+
+            var cityFileName = Path.GetFileNameWithoutExtension(cityPath);
+            var safeCityName = string.Concat(cityFileName.Select(c => char.IsLetterOrDigit(c) ? c : '_'));
+
+            var baseName = $"{prefix}_{safeCityName}";
+            var fileName = $"{baseName}{extension}";
+            var fullPath = Path.Combine(saveDirectory, fileName);
+
+            int counter = 1;
+            while (File.Exists(fullPath))
+            {
+                fileName = $"{baseName}_{counter}{extension}";
+                fullPath = Path.Combine(saveDirectory, fileName);
+                counter++;
+            }
+
+            return fullPath;
+        }
+    }
+}


### PR DESCRIPTION
- Refactored text file output paths in comparison classes (DwellingTypes, TypeOfUses, etc.) 
  to use PathHelper.GetUniqueFilePath
- Ensures all output is stored in the 'Saved Files' directory for consistency
- Removed use of Environment.CurrentDirectory for output paths
